### PR TITLE
[39기 강지민] ADD: login page loading 화면 구현

### DIFF
--- a/src/pages/Login/KakaoLogin.js
+++ b/src/pages/Login/KakaoLogin.js
@@ -1,5 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import variables from '../../styles/variables';
 
 export default function KakaoLogin() {
   const navigate = useNavigate();
@@ -21,5 +23,37 @@ export default function KakaoLogin() {
       });
   }, []);
 
-  return <div>로그인 중 입니다.</div>;
+  const completionWord = '로그인 중입니다...';
+  const [loginStatus, setLoginStatus] = useState('');
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const typingInterval = setInterval(() => {
+      setLoginStatus(prevStatusValue => {
+        let result = prevStatusValue
+          ? prevStatusValue + completionWord[count]
+          : completionWord[0];
+        setCount(count + 1);
+        if (count >= completionWord.length) {
+          setCount(0);
+          setLoginStatus('');
+        }
+        return result;
+      });
+    }, 200);
+    return () => {
+      clearInterval(typingInterval);
+    };
+  });
+
+  return <KakaoLoginWrap>{loginStatus}</KakaoLoginWrap>;
 }
+
+const KakaoLoginWrap = styled.div`
+  width: 100%;
+  height: 600px;
+  font-size: 40px;
+  font-weight: bold;
+  color: #882dc4;
+  ${variables.flex('column', 'center', 'center')};
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 소셜로그인 시 이동하는 중간 페이지의 로딩화면 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 타이핑 효과 구현
- useState와 setInterval을 사용해서 타이핑되는 듯한 화면을 구현


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 스피너 라이브러리를 사용할까 하다가 타이핑되는 듯한 화면을 만들어보고 싶어서 구현해봤다.

<br />

## :: 기타 질문 및 특이 사항
- 
